### PR TITLE
Set verbose level to remove debug logging

### DIFF
--- a/check_routeros.py
+++ b/check_routeros.py
@@ -223,6 +223,9 @@ def cli(ctx, host: str, hostname: Optional[str], port: int, username: str, passw
     ctx.obj["ssl_verify_hostname"] = ssl_verify_hostname
     ctx.obj["verbose"] = verbose
 
+    runtime = nagiosplugin.Runtime()
+    runtime.verbose = verbose
+
 
 #########################
 # Check: Interface GRE #


### PR DESCRIPTION
- Set verbose level as early as possible to remove debug output if verbose level is WARNING