### PR TITLE
Fix typo in name of month

### DIFF
--- a/check_routeros.py
+++ b/check_routeros.py
@@ -87,7 +87,7 @@ class RouterOSCheckResource(nagiosplugin.Resource):
             "feb": 2,
             "mar": 3,
             "apr": 4,
-            "mai": 5,
+            "may": 5,
             "jun": 6,
             "jul": 7,
             "aug": 8,

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -8,10 +8,18 @@ import check_routeros
 class TestBase:
     def test_parse_routeros_datetime(self):
         check = check_routeros.RouterOSCheckResource(cmd_options={})
-        parsed_datetime = check.parse_routeros_datetime("oct/13/2022 22:59:59")
-        assert parsed_datetime == datetime(year=2022, month=10, day=13, hour=22, minute=59, second=59)
+
         parsed_datetime = check.parse_routeros_datetime("sep/20/2021 13:43:12")
         assert parsed_datetime == datetime(year=2021, month=9, day=20, hour=13, minute=43, second=12)
+
+        parsed_datetime = check.parse_routeros_datetime("oct/13/2022 22:59:59")
+        assert parsed_datetime == datetime(year=2022, month=10, day=13, hour=22, minute=59, second=59)
+
+        parsed_datetime = check.parse_routeros_datetime("Apr/05/2023 23:59:59")
+        assert parsed_datetime == datetime(year=2023, month=4, day=5, hour=23, minute=59, second=59)
+
+        parsed_datetime = check.parse_routeros_datetime("May/07/2023 22:59:59")
+        assert parsed_datetime == datetime(year=2023, month=5, day=7, hour=22, minute=59, second=59)
 
         # Build Time 6.47.9 (long-term)
         parsed_datetime = check.parse_routeros_datetime("Feb/08/2021 12:48:33")


### PR DESCRIPTION
The script is unable to parse May because of an typo.