### PR TITLE
CHR devices don't report l2mtu so we make it optional

### DIFF
--- a/routeros_check/check/interface.py
+++ b/routeros_check/check/interface.py
@@ -113,6 +113,8 @@ class InterfaceResource(RouterOSCheckResource):
                 "name": "l2mtu",
                 "type": int,
                 "min": 0,
+                # CHR devices don't report l2mtu
+                "missing_ok": True,
             },
             {
                 "name": "link-downs",


### PR DESCRIPTION
Reporting l2mtu is optional now and it is okay if it is missing.