### PR TITLE
Fix issue with ntp offset on ROS 7.x

### DIFF
--- a/routeros_check/check/system_ntp_client.py
+++ b/routeros_check/check/system_ntp_client.py
@@ -114,7 +114,7 @@ class SystemNtpClientResource(RouterOSCheckResource):
             self._routeros_metric_values += [
                 {"name": "freq-drift", "type": float},
                 {"name": "synced-stratum", "dst": "stratum", "type": int},
-                {"name": "system-offset", "dst": "offset", "type": float, "uom": "s"},
+                {"name": "system-offset", "dst": "offset", "type": lambda v: float(v) / 1000, "uom": "s"},
             ]
             self._check.add(
                 PerfdataScalarContext(


### PR DESCRIPTION
We reported the ntp offset for ROS 7.x as seconds as documented in the MikroTik wiki, but the value is in microseconds.