### PR TITLE
Fix issue with license date by parsing iso datetime

### DIFF
--- a/routeros_check/resource.py
+++ b/routeros_check/resource.py
@@ -164,15 +164,13 @@ class RouterOSCheckResource(nagiosplugin.Resource):
 
     @classmethod
     def parse_routeros_date(cls, date_string: str) -> date:
+        logger.debug(f"Parsing date string {date_string}")
         # Try iso date
         # Looks like they have switched date format in 7.11
-        m = cls.regex_date_iso.match(date_string)
-        if m:
-            return date(
-                year=int(m.group("year")),
-                month=int(m.group("month")),
-                day=int(m.group("day"))
-            )
+        try:
+            return date.fromisoformat(date_string)
+        except ValueError as e:
+            logger.debug(f"'{date_string}' is not in iso format: {str(e)}")
 
         # Try US date
         m = cls.regex_date.match(date_string)
@@ -194,6 +192,13 @@ class RouterOSCheckResource(nagiosplugin.Resource):
 
     @classmethod
     def parse_routeros_datetime(cls, datetime_string: str) -> datetime:
+        logger.debug(f"Parsing datetime string {datetime_string}")
+
+        try:
+            return datetime.fromisoformat(datetime_string)
+        except ValueError as e:
+            logger.debug(f"'{datetime_string}' is not in iso format: {str(e)}")
+
         m = cls.regex_datetime.match(datetime_string)
         if not m:
             raise ValueError("Unable to parse datetime string")

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -47,6 +47,9 @@ class TestBase:
         parsed_datetime = check.parse_routeros_datetime("Feb/08/2021 12:48:33")
         assert parsed_datetime == datetime(year=2021, month=2, day=8, hour=12, minute=48, second=33)
 
+        parsed_datetime = check.parse_routeros_datetime("2024-05-09 11:23:55")
+        assert parsed_datetime == datetime(year=2024, month=5, day=9, hour=11, minute=23, second=55)
+
     def test_parse_routeros_time(self):
         check = RouterOSCheckResource(cmd_options={})
         assert check.parse_routeros_time_duration("-8ms15us") == -0.008015


### PR DESCRIPTION
Mikrotik has changed the format of the license date and uses the iso format for date and time now.