### PR TITLE
Fix issue with interface speed in interface check

### DIFF
--- a/config/check_routeros.icinga2.conf
+++ b/config/check_routeros.icinga2.conf
@@ -103,17 +103,21 @@ object CheckCommand "routeros_interface" {
 		"--cookie-filename" = {
 			value = "$routeros_interface_cookie_filename$"
 		}
+		"--value-default" = {
+			value = "$routeros_interface_value_default$"
+			repeat_key = true
+		}
 		"--value-override" = {
 			value = "$routeros_interface_value_override$"
-      repeat_key = true
+			repeat_key = true
 		}
 		"--value-warning" = {
 			value = "$routeros_interface_value_warning$"
-      repeat_key = true
+			repeat_key = true
 		}
 		"--value-critical" = {
 			value = "$routeros_interface_value_critical$"
-      repeat_key = true
+			repeat_key = true
 		}
 	}
 
@@ -127,7 +131,7 @@ object CheckCommand "routeros_interface_gre" {
 	arguments += {
 		"--name" = {
 			value = "$routeros_interface_gre_name$"
-      repeat_key = true
+			repeat_key = true
 		}
 		"--regex" = {
 			set_if = "$routeros_interface_gre_regex$"
@@ -166,7 +170,7 @@ object CheckCommand "routeros_routing_bgp_peer" {
 	arguments += {
 		"--name" = {
 			value = "$routeros_routing_bgp_peer_name$"
-      repeat_key = true
+			repeat_key = true
 		}
 		"--regex" = {
 			set_if = "$routeros_routing_bgp_peer_regex$"
@@ -224,11 +228,11 @@ object CheckCommand "routeros_system_cpu" {
 		}
 		"--value-warning" = {
 			value = "$routeros_system_cpu_value_warning$"
-      repeat_key = true
+			repeat_key = true
 		}
 		"--value-critical" = {
 			value = "$routeros_system_cpu_value_critical$"
-      repeat_key = true
+			repeat_key = true
 		}
 		"--regex" = {
 			set_if = "$routeros_system_cpu_regex$"
@@ -265,11 +269,11 @@ object CheckCommand "routeros_system_fan" {
 	arguments += {
 		"--value-warning" = {
 			value = "$routeros_system_fan_value_warning$"
-      repeat_key = true
+			repeat_key = true
 		}
 		"--value-critical" = {
 			value = "$routeros_system_fan_value_critical$"
-      repeat_key = true
+			repeat_key = true
 		}
 		"--regex" = {
 			set_if = "$routeros_system_fan_regex$"
@@ -297,7 +301,7 @@ object CheckCommand "routeros_system_license" {
 		}
 		"--level" = {
 			value = "$routeros_system_license_levels$"
-      repeat_key = true
+			repeat_key = true
 		}
 	}
 
@@ -373,11 +377,11 @@ object CheckCommand "routeros_system_psu" {
 	arguments += {
 		"--value-warning" = {
 			value = "$routeros_system_psu_value_warning$"
-      repeat_key = true
+			repeat_key = true
 		}
 		"--value-critical" = {
 			value = "$routeros_system_psu_value_critical$"
-      repeat_key = true
+			repeat_key = true
 		}
 	}
 
@@ -390,11 +394,11 @@ object CheckCommand "routeros_system_temperature" {
 	arguments += {
 		"--value-warning" = {
 			value = "$routeros_system_temperature_value_warning$"
-      repeat_key = true
+			repeat_key = true
 		}
 		"--value-critical" = {
 			value = "$routeros_system_temperature_value_critical$"
-      repeat_key = true
+			repeat_key = true
 		}
 		"--regex" = {
 			set_if = "$routeros_system_temperature_regex$"

--- a/routeros_check/check/interface.py
+++ b/routeros_check/check/interface.py
@@ -250,17 +250,19 @@ class InterfaceResource(RouterOSCheckResource):
 
         logger.info("Fetching data ...")
         interface_ethernet_data = {}
-        call = api.path(
-            "/interface/ethernet"
-        )
-        call_results = tuple(call)
+        interface_count = len(tuple(api.path("/interface/ethernet")))
+        call_results = tuple(api(
+            "/interface/ethernet/monitor",
+            **{
+                "once": "",
+                "numbers": f"{','.join([str(i) for i in range(interface_count)])}"
+            }
+        ))
         for result in call_results:
-            # if "speed" in result:
-            if result["running"]:
-                if "speed" in result:
-                    interface_ethernet_data[result["name"]] = {
-                        "speed": result["speed"],
-                    }
+            if "rate" in result:
+                interface_ethernet_data[result["name"]] = {
+                    "speed": result["rate"],
+                }
 
         call = api.path(
             "/interface"


### PR DESCRIPTION
This fixes an issue while fetching the speed of an ethernet interface. This has been tested with devices running RouterOS 7.11+.