### PR TITLE
Bump Python version to 3.8+ (Fixes: #88)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - {name: '3.12', python: '3.12', os: ubuntu-latest, tox: py312}
           - {name: '3.11', python: '3.11', os: ubuntu-latest, tox: py311}
           - {name: '3.10', python: '3.10', os: ubuntu-latest, tox: py310}
           - {name: '3.9', python: '3.9', os: ubuntu-latest, tox: py39}
           - {name: '3.8', python: '3.8', os: ubuntu-latest, tox: py38}
-          - {name: '3.7', python: '3.7', os: ubuntu-latest, tox: py37}
           - {name: 'PyPy 3.9', python: pypy3.9, os: ubuntu-latest, tox: pypy39}
 
     steps:

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ It uses the API to fetch the required information.
 Requirements
 ------------
 
-- [Python](https://www.python.org/) >= 3.6
+- [Python](https://www.python.org/) >= 3.8 (Some checks might still run with older Python 3)
 - Python Packages
     - [Click](https://pypi.org/project/click/)
     - [librouteros](https://pypi.org/project/librouteros/)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "librouteros",
     "nagiosplugin",
 ]
-requires-python = ">=3.6"
+requires-python = ">=3.8"
 
 [project.urls]
 Homepage = "https://github.com/DinoTools/monitoring-check_routeros"

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: CC0-1.0
 
 [tox]
-envlist = py37,py38,py39,py310,py311,pypy39
+envlist = py38,py39,py310,py311,py312,pypy39
 
 [testenv]
 deps =
@@ -12,9 +12,9 @@ commands = pytest --cov routeros_check --cov-report=term-missing -v tests/
 
 [gh-actions]
 python =
-    3.7: py37
     3.8: py38
     3.9: py39
     3.10: py310
     3.11: py311
+    3.12: py312
     pypy3.9: pypy39


### PR DESCRIPTION
For some checks Python 3.8+ has been the minimum supported version for a while now. We just update the documentation and CI checks.