### PR TITLE
Error handling missing values

### DIFF
--- a/routeros_check/check/interface.py
+++ b/routeros_check/check/interface.py
@@ -30,9 +30,8 @@ class InterfaceResource(RouterOSCheckResource):
             default_values: List[str],
             override_values: List[str],
     ):
-        super().__init__(cmd_options=cmd_options)
+        super().__init__(cmd_options=cmd_options, check=check)
 
-        self._check = check
         self._interface_data: Optional[Dict[str, Any]] = None
         self.names: List[Union[Any]] = names
         self.regex = regex
@@ -450,6 +449,7 @@ def interface(
 ):
     """Check the state and the stats of interfaces"""
     check = nagiosplugin.Check()
+
     resource = InterfaceResource(
         cmd_options=ctx.obj,
         check=check,
@@ -464,7 +464,10 @@ def interface(
         override_values=override_values,
     )
 
-    check.add(resource)
+    check.add(
+        resource,
+    )
+
     check.results.add(
         nagiosplugin.Result(
             nagiosplugin.state.Ok,

--- a/routeros_check/check/interface_gre.py
+++ b/routeros_check/check/interface_gre.py
@@ -19,12 +19,13 @@ class InterfaceGREResource(RouterOSCheckResource):
     def __init__(
             self,
             cmd_options: Dict[str, Any],
+            check: nagiosplugin.Check,
             names: List[str],
             regex: bool,
             single_interface: bool,
             ignore_disabled: bool,
     ):
-        super().__init__(cmd_options=cmd_options)
+        super().__init__(cmd_options=cmd_options, check=check)
 
         self._interface_data: Optional[Dict[str, Any]] = None
         self.names: List[Union[Any]] = names
@@ -149,16 +150,17 @@ class InterfaceGRERunningContext(BooleanContext):
 @click.pass_context
 def interface_gre(ctx, names, regex, single, ignore_disabled):
     """Check the state of a GRE interface."""
+    check = nagiosplugin.Check()
+
     resource = InterfaceGREResource(
         cmd_options=ctx.obj,
+        check=check,
         names=names,
         regex=regex,
         single_interface=single,
         ignore_disabled=ignore_disabled,
     )
-    check = nagiosplugin.Check(
-        resource,
-    )
+    check.add(resource)
 
     if single:
         if len(resource.interface_names) == 1:

--- a/routeros_check/check/interface_vrrp.py
+++ b/routeros_check/check/interface_vrrp.py
@@ -15,8 +15,8 @@ from ..resource import RouterOSCheckResource
 class InterfaceVrrpCheck(RouterOSCheckResource):
     name = "VRRP"
 
-    def __init__(self, cmd_options, name, master_must):
-        super().__init__(cmd_options=cmd_options)
+    def __init__(self, cmd_options, check: nagiosplugin.Check, name, master_must):
+        super().__init__(cmd_options=cmd_options, check=check)
 
         self._name = name
         self.backup = None
@@ -108,9 +108,12 @@ class InterfaceVrrpMaster(BooleanContext):
 @click.pass_context
 def interface_vrrp(ctx, name, master):
     """Check the state of VRRP interfaces"""
-    check = nagiosplugin.Check(
+    check = nagiosplugin.Check()
+
+    check.add(
         InterfaceVrrpCheck(
             cmd_options=ctx.obj,
+            check=check,
             name=name,
             master_must=master,
         ),

--- a/routeros_check/check/routing_bgp_peer.py
+++ b/routeros_check/check/routing_bgp_peer.py
@@ -19,11 +19,12 @@ class RoutingBGPPeerResource(RouterOSCheckResource):
     def __init__(
             self,
             cmd_options: Dict[str, Any],
+            check: nagiosplugin.Check,
             names: List[str],
             regex: bool,
             single_peer: bool,
     ):
-        super().__init__(cmd_options=cmd_options)
+        super().__init__(cmd_options=cmd_options, check=check)
 
         self._peer_data: Optional[Dict[str, Any]] = None
         self.names: List[Union[Any]] = names
@@ -153,15 +154,19 @@ class RoutingBGPPeerSummary(nagiosplugin.Summary):
 )
 @click.pass_context
 def routing_bgp_peer(ctx, names, regex, single):
+    check = nagiosplugin.Check()
+
     resource = RoutingBGPPeerResource(
         cmd_options=ctx.obj,
+        check=check,
         names=names,
         regex=regex,
         single_peer=single,
     )
-    check = nagiosplugin.Check(
-        resource,
+
+    check.add(
         RoutingBGPPeerSummary(),
+        resource,
     )
 
     if single:

--- a/routeros_check/check/routing_ospf_neighbor.py
+++ b/routeros_check/check/routing_ospf_neighbor.py
@@ -20,11 +20,12 @@ class RoutingOSPFNeighborResource(RouterOSCheckResource):
     def __init__(
             self,
             cmd_options: Dict[str, Any],
+            check: nagiosplugin.Check,
             instance: str,
             router_id: str,
             area: Optional[str] = None
     ):
-        super().__init__(cmd_options=cmd_options)
+        super().__init__(cmd_options=cmd_options, check=check)
 
         self.area = area
         self.instance = instance
@@ -174,14 +175,15 @@ class RoutingOSPFNeighborSummary(nagiosplugin.Summary):
 @click.pass_context
 def routing_ospf_neighbors(ctx, area, instance, router_id):
     """Check the state of an OSPF neighbor"""
-    resource = RoutingOSPFNeighborResource(
-        cmd_options=ctx.obj,
-        area=area,
-        instance=instance,
-        router_id=router_id,
-    )
-    check = nagiosplugin.Check(
-        resource,
+    check = nagiosplugin.Check()
+
+    check.add(
+        RoutingOSPFNeighborResource(
+            cmd_options=ctx.obj,
+            area=area,
+            instance=instance,
+            router_id=router_id,
+        ),
         nagiosplugin.ScalarContext("priority"),
         nagiosplugin.ScalarContext("adjacency"),
         nagiosplugin.ScalarContext("state_changes"),

--- a/routeros_check/check/system_clock.py
+++ b/routeros_check/check/system_clock.py
@@ -22,9 +22,7 @@ class SystemClockResource(RouterOSCheckResource):
         cmd_options,
         check: nagiosplugin.Check,
     ):
-        super().__init__(cmd_options=cmd_options)
-
-        self._check = check
+        super().__init__(cmd_options=cmd_options, check=check)
 
     def probe(self):
         api = self._connect_api()
@@ -76,12 +74,11 @@ def system_clock(ctx, warning, critical):
     """This command reads the information from /system/clock to extract the required information."""
     check = nagiosplugin.Check()
 
-    resource = SystemClockResource(
-        cmd_options=ctx.obj,
-        check=check,
-    )
     check.add(
-        resource,
+        SystemClockResource(
+            cmd_options=ctx.obj,
+            check=check,
+        ),
         SimplePositiveFloatContext(
             name="time-diff",
             warning=warning,

--- a/routeros_check/check/system_cpu.py
+++ b/routeros_check/check/system_cpu.py
@@ -26,9 +26,7 @@ class SystemCpuResource(RouterOSCheckResource):
         critical_values: List[str],
         use_regex: bool
     ):
-        super().__init__(cmd_options=cmd_options)
-
-        self._check = check
+        super().__init__(cmd_options=cmd_options, check=check)
 
         self.values: Dict[str, float] = {}
         self.use_regex: bool = use_regex
@@ -164,15 +162,14 @@ def system_cpu(ctx, load_warning, load_critical, warning_values, critical_values
     """
     check = nagiosplugin.Check()
 
-    resource = SystemCpuResource(
-        cmd_options=ctx.obj,
-        check=check,
-        warning_values=warning_values,
-        critical_values=critical_values,
-        use_regex=use_regex,
-    )
     check.add(
-        resource,
+        SystemCpuResource(
+            cmd_options=ctx.obj,
+            check=check,
+            warning_values=warning_values,
+            critical_values=critical_values,
+            use_regex=use_regex,
+        ),
         nagiosplugin.ScalarContext(
             name="cpu-load",
             warning=load_warning,

--- a/routeros_check/check/system_disk.py
+++ b/routeros_check/check/system_disk.py
@@ -17,8 +17,8 @@ from ..resource import RouterOSCheckResource
 class SystemDiskResource(RouterOSCheckResource):
     name = "DISK"
 
-    def __init__(self, cmd_options):
-        super().__init__(cmd_options=cmd_options)
+    def __init__(self, cmd_options, check):
+        super().__init__(cmd_options=cmd_options, check=check)
 
         self.total_hdd_space: Optional[int] = None
         self._routeros_metric_values = [
@@ -107,10 +107,13 @@ class SystemDiskSummary(nagiosplugin.summary.Summary):
 @click.pass_context
 @nagiosplugin.guarded
 def system_disk(ctx, used, warning, critical, bad_blocks_warning, bad_blocks_critical):
-    check = nagiosplugin.Check(
+    check = nagiosplugin.Check()
+
+    check.add(
         SystemDiskResource(
             cmd_options=ctx.obj,
-        )
+            check=check,
+        ),
     )
 
     if used:

--- a/routeros_check/check/system_fan.py
+++ b/routeros_check/check/system_fan.py
@@ -23,9 +23,7 @@ class SystemFanResource(RouterOSCheckResource):
         critical_values: List[str],
         use_regex: bool
     ):
-        super().__init__(cmd_options=cmd_options)
-
-        self._check = check
+        super().__init__(cmd_options=cmd_options, check=check)
 
         self.fan_names: Set[str] = set()
         self.fan_values: Dict[str, int] = {}

--- a/routeros_check/check/system_license.py
+++ b/routeros_check/check/system_license.py
@@ -14,8 +14,8 @@ from ..resource import RouterOSCheckResource
 class SystemLicenseResource(RouterOSCheckResource):
     name = "License"
 
-    def __init__(self, cmd_options):
-        super().__init__(cmd_options=cmd_options)
+    def __init__(self, cmd_options, check: nagiosplugin.Check):
+        super().__init__(cmd_options=cmd_options, check=check)
 
         def days_left(value):
             time_delta = self.parse_routeros_datetime(value) - datetime.now()
@@ -119,10 +119,14 @@ class SystemLicenseLevelContext(nagiosplugin.Context):
 @click.pass_context
 @nagiosplugin.guarded
 def system_license(ctx, deadline_warning, deadline_critical, next_renewal_warning, next_renewal_critical, levels):
+    check = nagiosplugin.Check()
+
     resource = SystemLicenseResource(
         cmd_options=ctx.obj,
+        check=check,
     )
-    check = nagiosplugin.Check(resource)
+
+    check.add(resource)
 
     if resource.has_renewal:
         check.add(

--- a/routeros_check/check/system_memory.py
+++ b/routeros_check/check/system_memory.py
@@ -17,8 +17,8 @@ from ..resource import RouterOSCheckResource
 class SystemMemoryResource(RouterOSCheckResource):
     name = "MEMORY"
 
-    def __init__(self, cmd_options):
-        super().__init__(cmd_options=cmd_options)
+    def __init__(self, cmd_options, check: nagiosplugin.Check):
+        super().__init__(cmd_options=cmd_options, check=check)
 
         self.memory_total = None
 
@@ -87,10 +87,13 @@ class SystemMemorySummary(nagiosplugin.summary.Summary):
 @click.pass_context
 @nagiosplugin.guarded
 def system_memory(ctx, used, warning, critical):
-    check = nagiosplugin.Check(
+    check = nagiosplugin.Check()
+
+    check.add(
         SystemMemoryResource(
             cmd_options=ctx.obj,
-        )
+            check=check,
+        ),
     )
 
     if used:

--- a/routeros_check/check/system_ntp_client.py
+++ b/routeros_check/check/system_ntp_client.py
@@ -28,9 +28,7 @@ class SystemNtpClientResource(RouterOSCheckResource):
         stratum_warning: Optional[int] = None,
         stratum_critical: Optional[int] = None,
     ):
-        super().__init__(cmd_options=cmd_options)
-
-        self._check = check
+        super().__init__(cmd_options=cmd_options, check=check)
 
         self._expected_servers = expected_servers
         self._offset_warning = offset_warning
@@ -239,19 +237,18 @@ def system_clock(ctx, last_update_before_warning, last_update_before_critical, o
     """
     check = nagiosplugin.Check()
 
-    resource = SystemNtpClientResource(
-        cmd_options=ctx.obj,
-        check=check,
-        last_update_before_warning=last_update_before_warning,
-        last_update_before_critical=last_update_before_critical,
-        offset_warning=offset_warning,
-        offset_critical=offset_critical,
-        stratum_warning=stratum_warning,
-        stratum_critical=stratum_critical,
-        expected_servers=expected_servers,
-    )
     check.add(
-        resource,
+        SystemNtpClientResource(
+            cmd_options=ctx.obj,
+            check=check,
+            last_update_before_warning=last_update_before_warning,
+            last_update_before_critical=last_update_before_critical,
+            offset_warning=offset_warning,
+            offset_critical=offset_critical,
+            stratum_warning=stratum_warning,
+            stratum_critical=stratum_critical,
+            expected_servers=expected_servers,
+        ),
         SystemNtpClientSummary(),
         BooleanContext(
             name="enabled",

--- a/routeros_check/check/system_power.py
+++ b/routeros_check/check/system_power.py
@@ -17,9 +17,7 @@ class SystemPowerResource(RouterOSCheckResource):
         cmd_options,
         check: nagiosplugin.Check,
     ):
-        super().__init__(cmd_options=cmd_options)
-
-        self._check = check
+        super().__init__(cmd_options=cmd_options, check=check)
 
         self._routeros_metric_values = [
             {"name": "power-consumption", "type": float},

--- a/routeros_check/check/system_psu.py
+++ b/routeros_check/check/system_psu.py
@@ -20,9 +20,7 @@ class SystemPsuResource(RouterOSCheckResource):
         self, cmd_options, check: nagiosplugin.Check, warning_values: List[str], critical_values: List[str],
         no_psu_ok: bool,
     ):
-        super().__init__(cmd_options=cmd_options)
-
-        self._check = check
+        super().__init__(cmd_options=cmd_options, check=check)
 
         self.psu_names: Set[str] = set()
         self.psu_states: Dict[str, str] = {}

--- a/routeros_check/check/system_temperature.py
+++ b/routeros_check/check/system_temperature.py
@@ -23,9 +23,7 @@ class SystemTemperatureResource(RouterOSCheckResource):
         critical_values: List[str],
         use_regex: bool
     ):
-        super().__init__(cmd_options=cmd_options)
-
-        self._check = check
+        super().__init__(cmd_options=cmd_options, check=check)
 
         self.names: Set[str] = set()
         self.values: Dict[str, float] = {}

--- a/routeros_check/check/system_update.py
+++ b/routeros_check/check/system_update.py
@@ -21,9 +21,8 @@ class SystemUpdateResource(RouterOSCheckResource):
         check_for_update: bool = False,
         latest_version: Optional[str] = None,
     ):
-        super().__init__(cmd_options=cmd_options)
+        super().__init__(cmd_options=cmd_options, check=check)
 
-        self._check = check
         self._check_for_update = check_for_update
         self._installed_version = None
         self._latest_version = None

--- a/routeros_check/check/system_uptime.py
+++ b/routeros_check/check/system_uptime.py
@@ -15,8 +15,8 @@ from ..resource import RouterOSCheckResource
 class SystemUptimeResource(RouterOSCheckResource):
     name = "UPTIME"
 
-    def __init__(self, cmd_options):
-        super().__init__(cmd_options=cmd_options)
+    def __init__(self, cmd_options, check: nagiosplugin.Check):
+        super().__init__(cmd_options=cmd_options, check=check)
 
     def probe(self):
         api = self._connect_api()
@@ -73,9 +73,12 @@ class UptimeSimpleScalarContext(nagiosplugin.ScalarContext):
 @nagiosplugin.guarded
 def system_uptime(ctx, warning, critical):
     """Get Uptime of a device"""
-    check = nagiosplugin.Check(
+    check = nagiosplugin.Check()
+
+    check.add(
         SystemUptimeResource(
             cmd_options=ctx.obj,
+            check=check,
         ),
         UptimeSimpleScalarContext(
             name="uptime",

--- a/routeros_check/check/tool_ping.py
+++ b/routeros_check/check/tool_ping.py
@@ -15,8 +15,8 @@ from ..resource import RouterOSCheckResource
 class ToolPingCheck(RouterOSCheckResource):
     name = "PING"
 
-    def __init__(self, cmd_options, address):
-        super().__init__(cmd_options=cmd_options)
+    def __init__(self, cmd_options, check: nagiosplugin.Check, address):
+        super().__init__(cmd_options=cmd_options, check=check)
 
         self._address = address
         self._max_packages = 1
@@ -109,42 +109,42 @@ class ToolPingCheck(RouterOSCheckResource):
 @click.pass_context
 def tool_ping(ctx, address, packet_loss_warning, packet_loss_critical, ttl_warning, ttl_critical):
     """Execute a ping command on the device to check other devices"""
-    check = nagiosplugin.Check(
+    check = nagiosplugin.Check()
+
+    check.add(
         ToolPingCheck(
             cmd_options=ctx.obj,
+            check=check,
             address=address
-        )
+        ),
+        nagiosplugin.ScalarContext(
+            name="packet_loss",
+            warning=packet_loss_warning,
+            critical=packet_loss_critical
+        ),
+        nagiosplugin.ScalarContext(
+            name="sent"
+        ),
+        nagiosplugin.ScalarContext(
+            name="received"
+        ),
+        nagiosplugin.ScalarContext(
+            name="rtt_avg"
+        ),
+        nagiosplugin.ScalarContext(
+            name="rtt_min"
+        ),
+        nagiosplugin.ScalarContext(
+            name="rtt_max"
+        ),
+        nagiosplugin.ScalarContext(
+            name="size"
+        ),
+        nagiosplugin.ScalarContext(
+            name="ttl",
+            warning=ttl_warning,
+            critical=ttl_critical
+        ),
     )
-
-    check.add(nagiosplugin.ScalarContext(
-        name="packet_loss",
-        warning=packet_loss_warning,
-        critical=packet_loss_critical
-    ))
-    check.add(nagiosplugin.ScalarContext(
-        name="sent"
-    ))
-    check.add(nagiosplugin.ScalarContext(
-        name="received"
-    ))
-
-    check.add(nagiosplugin.ScalarContext(
-        name="rtt_avg"
-    ))
-    check.add(nagiosplugin.ScalarContext(
-        name="rtt_min"
-    ))
-    check.add(nagiosplugin.ScalarContext(
-        name="rtt_max"
-    ))
-
-    check.add(nagiosplugin.ScalarContext(
-        name="size"
-    ))
-    check.add(nagiosplugin.ScalarContext(
-        name="ttl",
-        warning=ttl_warning,
-        critical=ttl_critical
-    ))
 
     check.main(verbose=ctx.obj["verbose"])

--- a/routeros_check/resource.py
+++ b/routeros_check/resource.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 from datetime import date, datetime, time
 from decimal import Decimal
+from pprint import pformat
 import re
 import ssl
 from typing import Any, Dict, List, Optional, Union
@@ -425,8 +426,7 @@ class RouterOSCheckResource(nagiosplugin.Resource):
                 elapsed_seconds = delta_time.total_seconds()
 
         if isinstance(api_results, dict):
-            from pprint import pprint
-            pprint(api_results)
+            logger.debug(f"Extracted values {pformat(api_results)}")
             api_results = self._convert_v6_list_to_v7(api_results=api_results)
 
         #


### PR DESCRIPTION
Don't return an exception if a value is missing. Return state unknown and report the name of the missing value.