### PR TITLE
Fix issue with missing interface metrics (Refs #75)

### DIFF
--- a/routeros_check/check/interface.py
+++ b/routeros_check/check/interface.py
@@ -134,6 +134,7 @@ class InterfaceResource(RouterOSCheckResource):
             },
             {
                 "name": "rx-drop",
+                "missing_ok": True,  # Missing for some interface like sfp28 and qsfp28
                 "type": int,
                 "min": 0,
                 "uom": "c",
@@ -141,6 +142,7 @@ class InterfaceResource(RouterOSCheckResource):
             },
             {
                 "name": "rx-error",
+                "missing_ok": True,  # Missing for some interface like sfp28 and qsfp28
                 "type": int,
                 "min": 0,
                 "uom": "c",
@@ -163,6 +165,7 @@ class InterfaceResource(RouterOSCheckResource):
             },
             {
                 "name": "tx-drop",
+                "missing_ok": True,  # Missing for some interface like sfp28 and qsfp28
                 "type": int,
                 "min": 0,
                 "uom": "c",
@@ -170,6 +173,7 @@ class InterfaceResource(RouterOSCheckResource):
             },
             {
                 "name": "tx-error",
+                "missing_ok": True,  # Missing for some interface like sfp28 and qsfp28
                 "type": int,
                 "min": 0,
                 "uom": "c",


### PR DESCRIPTION
Some interfaces like sfp28 and qsfp28 don't report some values like:

- rx-drop
- rx-error
- tx-drop
- tx-error

Add flag to ignore missing values