### PR TITLE
Fix issue with detecting CHR devices Fixes #106

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+0.11.1 - 2025-10-21
+-------------------
+
+### Fixed
+
+- Improved system identification in virtualized environments:
+  The board name for Cloud Hosted Router (CHR) installations now displays the specific virtualization platform name instead of the generic "CHR".
+  Example: "CHR" -> "CHR VMware, Inc. VMware Virtual Platform"
+
 0.11.0 - 2025-07-11
 -------------------
 

--- a/routeros_check/check/system_license.py
+++ b/routeros_check/check/system_license.py
@@ -27,7 +27,7 @@ class SystemLicenseResource(RouterOSCheckResource):
         )
         result = tuple(call)[0]
 
-        self.has_renewal = result["board-name"].lower() == "chr"
+        self.has_renewal = result["board-name"].lower().startswith("chr")
 
         self.deadline_datetime: Optional[datetime] = None
         self.next_renewal_datetime: Optional[datetime] = None


### PR DESCRIPTION
Improved system identification in virtualized environments: he board name for Cloud Hosted Router (CHR) installations now displays the specific virtualization platform name instead of the generic "CHR". Example: "CHR" -> "CHR VMware, Inc. VMware Virtual Platform"